### PR TITLE
Deepgram WebSocketリアルタイム文字起こしの基盤を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Deepgram credentials
+# Get your API key and project ID at https://console.deepgram.com/
+DEEPGRAM_API_KEY=your_deepgram_api_key_here
+DEEPGRAM_PROJECT_ID=your_deepgram_project_id_here

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 # Deepgram credentials
 # Get your API key and project ID at https://console.deepgram.com/
 DEEPGRAM_API_KEY=your_deepgram_api_key_here
-DEEPGRAM_PROJECT_ID=your_deepgram_project_id_here

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/app/api/transcribe/token/route.ts
+++ b/app/api/transcribe/token/route.ts
@@ -3,7 +3,7 @@ import { deepgram } from "@/lib/deepgram";
 
 export async function POST() {
   try {
-    const response = await deepgram.auth.v1.tokens.grant();
+    const response = await deepgram.auth.v1.tokens.grant({ ttl: 30 });
     return NextResponse.json({ token: response.access_token });
   } catch {
     return NextResponse.json({ error: "Failed to create token" }, { status: 500 });

--- a/app/api/transcribe/token/route.ts
+++ b/app/api/transcribe/token/route.ts
@@ -1,0 +1,19 @@
+import { deepgram } from "@/lib/deepgram";
+import { NextResponse } from "next/server";
+
+// Returns a short-lived JWT (30 seconds TTL) for client-side WebSocket connections.
+// The client uses this token to connect directly to Deepgram's real-time transcription
+// WebSocket without exposing the primary API key.
+//
+// Client WebSocket URL:
+//   wss://api.deepgram.com/v1/listen?model=nova-3&language=ja&...
+// Authorization header:
+//   token <access_token>
+export async function POST() {
+  try {
+    const response = await deepgram.auth.v1.tokens.grant();
+    return NextResponse.json({ token: response.access_token });
+  } catch {
+    return NextResponse.json({ error: "Failed to create token" }, { status: 500 });
+  }
+}

--- a/app/api/transcribe/token/route.ts
+++ b/app/api/transcribe/token/route.ts
@@ -5,7 +5,8 @@ export async function POST() {
   try {
     const response = await deepgram.auth.v1.tokens.grant({ ttl: 30 });
     return NextResponse.json({ token: response.access_token });
-  } catch {
+  } catch (error) {
+    console.error("Failed to create Deepgram token", error);
     return NextResponse.json({ error: "Failed to create token" }, { status: 500 });
   }
 }

--- a/app/api/transcribe/token/route.ts
+++ b/app/api/transcribe/token/route.ts
@@ -1,14 +1,6 @@
-import { deepgram } from "@/lib/deepgram";
 import { NextResponse } from "next/server";
+import { deepgram } from "@/lib/deepgram";
 
-// Returns a short-lived JWT (30 seconds TTL) for client-side WebSocket connections.
-// The client uses this token to connect directly to Deepgram's real-time transcription
-// WebSocket without exposing the primary API key.
-//
-// Client WebSocket URL:
-//   wss://api.deepgram.com/v1/listen?model=nova-3&language=ja&...
-// Authorization header:
-//   token <access_token>
 export async function POST() {
   try {
     const response = await deepgram.auth.v1.tokens.grant();

--- a/lib/deepgram.ts
+++ b/lib/deepgram.ts
@@ -1,0 +1,7 @@
+import { DefaultDeepgramClient } from "@deepgram/sdk";
+
+if (!process.env.DEEPGRAM_API_KEY) {
+  throw new Error("DEEPGRAM_API_KEY is not set");
+}
+
+export const deepgram = new DefaultDeepgramClient({ apiKey: process.env.DEEPGRAM_API_KEY });

--- a/lib/deepgram.ts
+++ b/lib/deepgram.ts
@@ -1,11 +1,11 @@
 import { DefaultDeepgramClient } from "@deepgram/sdk";
 
-if (!process.env.DEEPGRAM_API_KEY) {
-  throw new Error("DEEPGRAM_API_KEY is not set");
-}
-
 function createDeepgramClient() {
-  return new DefaultDeepgramClient({ apiKey: process.env.DEEPGRAM_API_KEY });
+  const apiKey = process.env.DEEPGRAM_API_KEY;
+  if (!apiKey) {
+    throw new Error("DEEPGRAM_API_KEY is not set");
+  }
+  return new DefaultDeepgramClient({ apiKey });
 }
 
 const globalForDeepgram = globalThis as unknown as { deepgram: DefaultDeepgramClient };

--- a/lib/deepgram.ts
+++ b/lib/deepgram.ts
@@ -4,4 +4,12 @@ if (!process.env.DEEPGRAM_API_KEY) {
   throw new Error("DEEPGRAM_API_KEY is not set");
 }
 
-export const deepgram = new DefaultDeepgramClient({ apiKey: process.env.DEEPGRAM_API_KEY });
+function createDeepgramClient() {
+  return new DefaultDeepgramClient({ apiKey: process.env.DEEPGRAM_API_KEY });
+}
+
+const globalForDeepgram = globalThis as unknown as { deepgram: DefaultDeepgramClient };
+
+export const deepgram = globalForDeepgram.deepgram ?? createDeepgramClient();
+
+if (process.env.NODE_ENV !== "production") globalForDeepgram.deepgram = deepgram;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:studio": "prisma studio"
   },
   "dependencies": {
+    "@deepgram/sdk": "^5.0.0",
     "@libsql/client": "^0.17.2",
     "@prisma/adapter-libsql": "^7.5.0",
     "@prisma/client": "^7.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@deepgram/sdk':
+        specifier: ^5.0.0
+        version: 5.0.0
       '@libsql/client':
         specifier: ^0.17.2
         version: 0.17.2
@@ -281,6 +284,10 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@deepgram/sdk@5.0.0':
+    resolution: {integrity: sha512-x1wMiOgDGqcLEaQpQBQLTtk5mLbXbYgcBEpp7cfJIyEtqdIGgijCZH+a/esiVp+xIcTYYroTxG47RVppZOHbWw==}
+    engines: {node: '>=18.0.0'}
 
   '@electric-sql/pglite-socket@0.0.20':
     resolution: {integrity: sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==}
@@ -3262,6 +3269,13 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@deepgram/sdk@5.0.0':
+    dependencies:
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@electric-sql/pglite-socket@0.0.20(@electric-sql/pglite@0.3.15)':
     dependencies:

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: process.env["DATABASE_URL"],
+    url: process.env.DATABASE_URL,
   },
 });


### PR DESCRIPTION
- @deepgram/sdk v5 をインストール
- lib/deepgram.ts: DeepgramClient のシングルトンを作成
- app/api/transcribe/token/route.ts: クライアント向け短命JWTトークン発行エンドポイント
- .env.example: DEEPGRAM_API_KEY / DEEPGRAM_PROJECT_ID のテンプレートを追加
- .gitignore: .env.example は除外対象から外す

https://claude.ai/code/session_01FhqAHy4C2jsEciuiYLh4LQ