### PR TITLE
feat: 聴講者ビューとパーソナライズAPIを追加

### DIFF
--- a/app/[sessionId]/page.tsx
+++ b/app/[sessionId]/page.tsx
@@ -16,6 +16,7 @@ type DisplaySegment = {
   personalizedText: string | null;
   isFeedbackPending: boolean;
   feedbackDone: boolean;
+  feedbackError: boolean;
 };
 
 const PERSONA_KEY = "vivaldi:userPersona";
@@ -85,7 +86,7 @@ export default function AttendeePage({ params }: { params: { sessionId: string }
         const { id, polishedText } = data;
         setSegments((prev) => {
           if (prev.some((s) => s.id === id)) return prev;
-          return [...prev, { id, polishedText, personalizedText: null, isFeedbackPending: false, feedbackDone: false }];
+          return [...prev, { id, polishedText, personalizedText: null, isFeedbackPending: false, feedbackDone: false, feedbackError: false }];
         });
         // Personalize in background
         const currentPersona = personaRef.current;
@@ -119,14 +120,19 @@ export default function AttendeePage({ params }: { params: { sessionId: string }
         const body = (await res.json()) as { updatedPersona: UserPersona };
         personaRef.current = body.updatedPersona;
         savePersona(body.updatedPersona);
+        setSegments((prev) =>
+          prev.map((s) => (s.id === segmentId ? { ...s, isFeedbackPending: false, feedbackDone: true } : s)),
+        );
+      } else {
+        setSegments((prev) =>
+          prev.map((s) => (s.id === segmentId ? { ...s, isFeedbackPending: false, feedbackError: true } : s)),
+        );
       }
     } catch {
-      // silently fail
+      setSegments((prev) =>
+        prev.map((s) => (s.id === segmentId ? { ...s, isFeedbackPending: false, feedbackError: true } : s)),
+      );
     }
-
-    setSegments((prev) =>
-      prev.map((s) => (s.id === segmentId ? { ...s, isFeedbackPending: false, feedbackDone: true } : s)),
-    );
   }, []);
 
   if (notFound) {
@@ -201,6 +207,9 @@ export default function AttendeePage({ params }: { params: { sessionId: string }
                 )}
                 {seg.feedbackDone && (
                   <span className="mt-3 inline-block text-xs text-orange-500">フィードバックを送りました</span>
+                )}
+                {seg.feedbackError && (
+                  <span className="mt-3 inline-block text-xs text-red-500">送信に失敗しました。もう一度お試しください</span>
                 )}
               </div>
             ))}

--- a/app/[sessionId]/page.tsx
+++ b/app/[sessionId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { type UserPersona, defaultPersona, parsePersona } from "@/lib/persona";
+import { defaultPersona, parsePersona, type UserPersona } from "@/lib/persona";
 
 type SessionStatus = "BEFORE" | "DURING" | "AFTER";
 
@@ -75,7 +75,17 @@ export default function AttendeePage({ params }: { params: { sessionId: string }
         const { id, polishedText } = data;
         setSegments((prev) => {
           if (prev.some((s) => s.id === id)) return prev;
-          return [...prev, { id, polishedText, personalizedText: null, isFeedbackPending: false, feedbackDone: false, feedbackError: false }];
+          return [
+            ...prev,
+            {
+              id,
+              polishedText,
+              personalizedText: null,
+              isFeedbackPending: false,
+              feedbackDone: false,
+              feedbackError: false,
+            },
+          ];
         });
         // Personalize in background
         const currentPersona = personaRef.current;
@@ -206,7 +216,9 @@ export default function AttendeePage({ params }: { params: { sessionId: string }
                   <span className="mt-3 inline-block text-xs text-orange-500">フィードバックを送りました</span>
                 )}
                 {seg.feedbackError && (
-                  <span className="mt-3 inline-block text-xs text-red-500">送信に失敗しました。もう一度お試しください</span>
+                  <span className="mt-3 inline-block text-xs text-red-500">
+                    送信に失敗しました。もう一度お試しください
+                  </span>
                 )}
               </div>
             ))}

--- a/app/[sessionId]/page.tsx
+++ b/app/[sessionId]/page.tsx
@@ -1,14 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { type UserPersona, defaultPersona, parsePersona } from "@/lib/persona";
 
 type SessionStatus = "BEFORE" | "DURING" | "AFTER";
-
-type UserPersona = {
-  knownDomains: string[];
-  unknownDomains: string[];
-  feedbackHistory: Array<{ inference: string; timestamp: number }>;
-};
 
 type DisplaySegment = {
   id: number;
@@ -21,18 +16,12 @@ type DisplaySegment = {
 
 const PERSONA_KEY = "vivaldi:userPersona";
 
-const defaultPersona: UserPersona = {
-  knownDomains: [],
-  unknownDomains: [],
-  feedbackHistory: [],
-};
-
 function loadPersona(): UserPersona {
   if (typeof window === "undefined") return defaultPersona;
   try {
     const raw = localStorage.getItem(PERSONA_KEY);
     if (!raw) return defaultPersona;
-    return JSON.parse(raw) as UserPersona;
+    return parsePersona(JSON.parse(raw));
   } catch {
     return defaultPersona;
   }

--- a/app/[sessionId]/page.tsx
+++ b/app/[sessionId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 type SessionStatus = "BEFORE" | "DURING" | "AFTER";
 
@@ -57,8 +57,8 @@ async function fetchPersonalized(text: string, userPersona: UserPersona): Promis
   }
 }
 
-export default function AttendeePage({ params }: { params: Promise<{ sessionId: string }> }) {
-  const { sessionId } = use(params);
+export default function AttendeePage({ params }: { params: { sessionId: string } }) {
+  const { sessionId } = params;
 
   const [sessionStatus, setSessionStatus] = useState<SessionStatus | null>(null);
   const [segments, setSegments] = useState<DisplaySegment[]>([]);

--- a/app/[sessionId]/page.tsx
+++ b/app/[sessionId]/page.tsx
@@ -96,9 +96,17 @@ export default function AttendeePage({ params }: { params: { sessionId: string }
     };
 
     es.onerror = () => {
-      // If session not found the server returns 404 before stream; detect via close
-      setNotFound(true);
+      // Close the stream on error, then check if the session actually exists.
       es.close();
+      void fetch(`/api/sessions/${sessionId}`)
+        .then((res) => {
+          if (res.status === 404) {
+            setNotFound(true);
+          }
+        })
+        .catch(() => {
+          // Treat network/server errors as transient: do not mark as notFound here.
+        });
     };
 
     return () => {

--- a/app/[sessionId]/page.tsx
+++ b/app/[sessionId]/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { use, useCallback, useEffect, useRef, useState } from "react";
+
+type SessionStatus = "BEFORE" | "DURING" | "AFTER";
+
+type UserPersona = {
+  knownDomains: string[];
+  unknownDomains: string[];
+  feedbackHistory: Array<{ inference: string; timestamp: number }>;
+};
+
+type DisplaySegment = {
+  id: number;
+  polishedText: string;
+  personalizedText: string | null;
+  isFeedbackPending: boolean;
+  feedbackDone: boolean;
+};
+
+const PERSONA_KEY = "vivaldi:userPersona";
+
+const defaultPersona: UserPersona = {
+  knownDomains: [],
+  unknownDomains: [],
+  feedbackHistory: [],
+};
+
+function loadPersona(): UserPersona {
+  if (typeof window === "undefined") return defaultPersona;
+  try {
+    const raw = localStorage.getItem(PERSONA_KEY);
+    if (!raw) return defaultPersona;
+    return JSON.parse(raw) as UserPersona;
+  } catch {
+    return defaultPersona;
+  }
+}
+
+function savePersona(persona: UserPersona): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(PERSONA_KEY, JSON.stringify(persona));
+}
+
+async function fetchPersonalized(text: string, userPersona: UserPersona): Promise<string> {
+  try {
+    const res = await fetch("/api/personalize", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text, userPersona }),
+    });
+    if (!res.ok) return text;
+    const body = (await res.json()) as { personalized?: string };
+    return body.personalized ?? text;
+  } catch {
+    return text;
+  }
+}
+
+export default function AttendeePage({ params }: { params: Promise<{ sessionId: string }> }) {
+  const { sessionId } = use(params);
+
+  const [sessionStatus, setSessionStatus] = useState<SessionStatus | null>(null);
+  const [segments, setSegments] = useState<DisplaySegment[]>([]);
+  const [notFound, setNotFound] = useState(false);
+  const personaRef = useRef<UserPersona>(defaultPersona);
+
+  // Load persona from localStorage after mount
+  useEffect(() => {
+    personaRef.current = loadPersona();
+  }, []);
+
+  // SSE subscription
+  useEffect(() => {
+    const es = new EventSource(`/api/sessions/${sessionId}/stream`);
+
+    es.onmessage = (event) => {
+      const data = JSON.parse(event.data as string) as
+        | { type: "session"; status: SessionStatus }
+        | { type: "segment"; id: number; polishedText: string; rawText: string };
+
+      if (data.type === "session") {
+        setSessionStatus(data.status);
+      } else if (data.type === "segment") {
+        const { id, polishedText } = data;
+        setSegments((prev) => {
+          if (prev.some((s) => s.id === id)) return prev;
+          return [...prev, { id, polishedText, personalizedText: null, isFeedbackPending: false, feedbackDone: false }];
+        });
+        // Personalize in background
+        const currentPersona = personaRef.current;
+        void fetchPersonalized(polishedText, currentPersona).then((personalizedText) => {
+          setSegments((prev) => prev.map((s) => (s.id === id ? { ...s, personalizedText } : s)));
+        });
+      }
+    };
+
+    es.onerror = () => {
+      // If session not found the server returns 404 before stream; detect via close
+      setNotFound(true);
+      es.close();
+    };
+
+    return () => {
+      es.close();
+    };
+  }, [sessionId]);
+
+  const handleFeedback = useCallback(async (segmentId: number, text: string) => {
+    setSegments((prev) => prev.map((s) => (s.id === segmentId ? { ...s, isFeedbackPending: true } : s)));
+
+    try {
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text, userPersona: personaRef.current }),
+      });
+      if (res.ok) {
+        const body = (await res.json()) as { updatedPersona: UserPersona };
+        personaRef.current = body.updatedPersona;
+        savePersona(body.updatedPersona);
+      }
+    } catch {
+      // silently fail
+    }
+
+    setSegments((prev) =>
+      prev.map((s) => (s.id === segmentId ? { ...s, isFeedbackPending: false, feedbackDone: true } : s)),
+    );
+  }, []);
+
+  if (notFound) {
+    return (
+      <main className="min-h-screen bg-gray-50 flex items-center justify-center p-8">
+        <div className="text-center">
+          <p className="text-lg text-gray-500">セッションが見つかりません</p>
+          <p className="text-sm text-gray-400 mt-2">URLを確認してください</p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 p-6">
+      <div className="max-w-2xl mx-auto">
+        <div className="mb-6 flex items-center gap-3">
+          <h1 className="text-xl font-bold text-gray-900">リアルタイム意訳</h1>
+          {sessionStatus && (
+            <span
+              className={[
+                "px-2.5 py-0.5 rounded-full text-xs font-medium",
+                sessionStatus === "BEFORE"
+                  ? "bg-gray-100 text-gray-600"
+                  : sessionStatus === "DURING"
+                    ? "bg-green-100 text-green-700"
+                    : "bg-blue-100 text-blue-700",
+              ].join(" ")}
+            >
+              {sessionStatus === "BEFORE" && "発表前"}
+              {sessionStatus === "DURING" && "発表中"}
+              {sessionStatus === "AFTER" && "発表終了"}
+            </span>
+          )}
+        </div>
+
+        {(sessionStatus === null || sessionStatus === "BEFORE") && (
+          <div className="bg-white rounded-xl border border-gray-200 p-10 text-center">
+            <div className="w-10 h-10 mx-auto mb-4 rounded-full bg-gray-100 flex items-center justify-center">
+              <span className="text-gray-400 text-lg">●</span>
+            </div>
+            <p className="text-gray-500 font-medium">発表開始をお待ちください</p>
+          </div>
+        )}
+
+        {sessionStatus === "DURING" && segments.length === 0 && (
+          <div className="bg-white rounded-xl border border-gray-200 p-10 text-center">
+            <p className="text-gray-400 text-sm">まもなくテキストが表示されます…</p>
+          </div>
+        )}
+
+        {segments.length > 0 && (
+          <div className="space-y-3">
+            {segments.map((seg) => (
+              <div key={seg.id} className="bg-white rounded-xl border border-gray-200 p-5">
+                <p className="text-base leading-relaxed text-gray-900">{seg.personalizedText ?? seg.polishedText}</p>
+                {seg.personalizedText === null && <p className="text-xs text-gray-400 mt-1">意訳中…</p>}
+                {!seg.feedbackDone && (
+                  <button
+                    type="button"
+                    disabled={seg.isFeedbackPending}
+                    onClick={() => void handleFeedback(seg.id, seg.personalizedText ?? seg.polishedText)}
+                    className={[
+                      "mt-3 text-xs px-3 py-1 rounded-full border transition-colors",
+                      seg.isFeedbackPending
+                        ? "border-gray-200 text-gray-300 cursor-not-allowed"
+                        : "border-gray-300 text-gray-500 hover:border-orange-300 hover:text-orange-600",
+                    ].join(" ")}
+                  >
+                    {seg.isFeedbackPending ? "送信中…" : "わかりにくい"}
+                  </button>
+                )}
+                {seg.feedbackDone && (
+                  <span className="mt-3 inline-block text-xs text-orange-500">フィードバックを送りました</span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {sessionStatus === "AFTER" && segments.length > 0 && (
+          <p className="mt-6 text-center text-sm text-gray-400">発表が終了しました</p>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -47,9 +47,7 @@ ${JSON.stringify(persona)}
     const inference = response.text?.trim() ?? "";
     const updatedPersona = {
       ...persona,
-      feedbackHistory: [...persona.feedbackHistory, { inference, timestamp: Date.now() }].slice(
-        -MAX_FEEDBACK_HISTORY,
-      ),
+      feedbackHistory: [...persona.feedbackHistory, { inference, timestamp: Date.now() }].slice(-MAX_FEEDBACK_HISTORY),
     };
 
     return NextResponse.json({ updatedPersona, inference });

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { gemini } from "@/lib/gemini";
+
+type UserPersona = {
+  knownDomains: string[];
+  unknownDomains: string[];
+  feedbackHistory: Array<{ inference: string; timestamp: number }>;
+};
+
+export async function POST(request: Request) {
+  let body: { text?: string; userPersona?: UserPersona };
+  try {
+    body = (await request.json()) as { text?: string; userPersona?: UserPersona };
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { text, userPersona } = body;
+  if (!text) {
+    return NextResponse.json({ error: "text is required" }, { status: 400 });
+  }
+
+  const persona: UserPersona = userPersona ?? {
+    knownDomains: [],
+    unknownDomains: [],
+    feedbackHistory: [],
+  };
+
+  try {
+    const response = await gemini.models.generateContent({
+      model: "gemini-2.0-flash",
+      contents: [
+        {
+          role: "user",
+          parts: [
+            {
+              text: `以下のテキストを読んだ聴講者が「わかりにくい」と感じました。
+
+【テキスト】
+${text}
+
+【現在の聴講者ペルソナ】
+${JSON.stringify(persona)}
+
+このテキストの何がわかりにくかったか、1〜2文で推測してください。
+例: "量子もつれなど量子力学固有の概念への不慣れが原因と考えられる"
+推測のみ返してください。`,
+            },
+          ],
+        },
+      ],
+    });
+
+    const inference = response.text?.trim() ?? "";
+    const updatedPersona: UserPersona = {
+      ...persona,
+      feedbackHistory: [...persona.feedbackHistory, { inference, timestamp: Date.now() }],
+    };
+
+    return NextResponse.json({ updatedPersona, inference });
+  } catch (err) {
+    console.error("feedback error:", err);
+    return NextResponse.json({ error: "Failed to process feedback" }, { status: 500 });
+  }
+}

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,30 +1,23 @@
 import { NextResponse } from "next/server";
 import { gemini } from "@/lib/gemini";
+import { parsePersona } from "@/lib/persona";
 
-type UserPersona = {
-  knownDomains: string[];
-  unknownDomains: string[];
-  feedbackHistory: Array<{ inference: string; timestamp: number }>;
-};
+const MAX_FEEDBACK_HISTORY = 10;
 
 export async function POST(request: Request) {
-  let body: { text?: string; userPersona?: UserPersona };
+  let body: { text?: string; userPersona?: unknown };
   try {
-    body = (await request.json()) as { text?: string; userPersona?: UserPersona };
+    body = (await request.json()) as { text?: string; userPersona?: unknown };
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const { text, userPersona } = body;
+  const { text } = body;
   if (!text) {
     return NextResponse.json({ error: "text is required" }, { status: 400 });
   }
 
-  const persona: UserPersona = userPersona ?? {
-    knownDomains: [],
-    unknownDomains: [],
-    feedbackHistory: [],
-  };
+  const persona = parsePersona(body.userPersona);
 
   try {
     const response = await gemini.models.generateContent({
@@ -51,9 +44,8 @@ ${JSON.stringify(persona)}
       ],
     });
 
-    const MAX_FEEDBACK_HISTORY = 10;
     const inference = response.text?.trim() ?? "";
-    const updatedPersona: UserPersona = {
+    const updatedPersona = {
       ...persona,
       feedbackHistory: [...persona.feedbackHistory, { inference, timestamp: Date.now() }].slice(
         -MAX_FEEDBACK_HISTORY,

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -51,10 +51,13 @@ ${JSON.stringify(persona)}
       ],
     });
 
+    const MAX_FEEDBACK_HISTORY = 10;
     const inference = response.text?.trim() ?? "";
     const updatedPersona: UserPersona = {
       ...persona,
-      feedbackHistory: [...persona.feedbackHistory, { inference, timestamp: Date.now() }],
+      feedbackHistory: [...persona.feedbackHistory, { inference, timestamp: Date.now() }].slice(
+        -MAX_FEEDBACK_HISTORY,
+      ),
     };
 
     return NextResponse.json({ updatedPersona, inference });

--- a/app/api/personalize/route.ts
+++ b/app/api/personalize/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { gemini } from "@/lib/gemini";
+
+type UserPersona = {
+  knownDomains: string[];
+  unknownDomains: string[];
+  feedbackHistory: Array<{ inference: string; timestamp: number }>;
+};
+
+function summarizePersona(persona: UserPersona): string {
+  const parts: string[] = [];
+  if (persona.knownDomains.length > 0) {
+    parts.push(`詳しい分野: ${persona.knownDomains.join("、")}`);
+  }
+  if (persona.unknownDomains.length > 0) {
+    parts.push(`不慣れな分野: ${persona.unknownDomains.join("、")}`);
+  }
+  if (persona.feedbackHistory.length > 0) {
+    const recent = persona.feedbackHistory.slice(-3).map((f) => f.inference);
+    parts.push(`過去のフィードバック: ${recent.join("／")}`);
+  }
+  return parts.length > 0 ? parts.join("。") : "特になし";
+}
+
+export async function POST(request: Request) {
+  let body: { text?: string; userPersona?: UserPersona };
+  try {
+    body = (await request.json()) as { text?: string; userPersona?: UserPersona };
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { text, userPersona } = body;
+  if (!text) {
+    return NextResponse.json({ error: "text is required" }, { status: 400 });
+  }
+
+  const persona: UserPersona = userPersona ?? {
+    knownDomains: [],
+    unknownDomains: [],
+    feedbackHistory: [],
+  };
+
+  try {
+    const response = await gemini.models.generateContent({
+      model: "gemini-2.0-flash",
+      contents: [
+        {
+          role: "user",
+          parts: [
+            {
+              text: `以下の発表テキストを、聴講者が理解しやすい表現に意訳してください。
+
+【聴講者の特性】
+${summarizePersona(persona)}
+
+【元のテキスト】
+${text}
+
+ルール:
+- 内容を変えず、表現だけを平易にする
+- 専門用語は聴講者が知らない可能性がある場合、括弧で簡潔な説明を補足する
+- 意訳後のテキストのみ返す`,
+            },
+          ],
+        },
+      ],
+    });
+
+    const personalized = response.text?.trim() ?? text;
+    return NextResponse.json({ personalized });
+  } catch (err) {
+    console.error("personalize error:", err);
+    return NextResponse.json({ error: "Failed to personalize text" }, { status: 500 });
+  }
+}

--- a/app/api/personalize/route.ts
+++ b/app/api/personalize/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { gemini } from "@/lib/gemini";
-import { type UserPersona, parsePersona } from "@/lib/persona";
+import { parsePersona, type UserPersona } from "@/lib/persona";
 
 function summarizePersona(persona: UserPersona): string {
   const parts: string[] = [];

--- a/app/api/personalize/route.ts
+++ b/app/api/personalize/route.ts
@@ -1,11 +1,6 @@
 import { NextResponse } from "next/server";
 import { gemini } from "@/lib/gemini";
-
-type UserPersona = {
-  knownDomains: string[];
-  unknownDomains: string[];
-  feedbackHistory: Array<{ inference: string; timestamp: number }>;
-};
+import { type UserPersona, parsePersona } from "@/lib/persona";
 
 function summarizePersona(persona: UserPersona): string {
   const parts: string[] = [];
@@ -23,23 +18,19 @@ function summarizePersona(persona: UserPersona): string {
 }
 
 export async function POST(request: Request) {
-  let body: { text?: string; userPersona?: UserPersona };
+  let body: { text?: string; userPersona?: unknown };
   try {
-    body = (await request.json()) as { text?: string; userPersona?: UserPersona };
+    body = (await request.json()) as { text?: string; userPersona?: unknown };
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const { text, userPersona } = body;
+  const { text } = body;
   if (!text) {
     return NextResponse.json({ error: "text is required" }, { status: 400 });
   }
 
-  const persona: UserPersona = userPersona ?? {
-    knownDomains: [],
-    unknownDomains: [],
-    feedbackHistory: [],
-  };
+  const persona = parsePersona(body.userPersona);
 
   try {
     const response = await gemini.models.generateContent({

--- a/lib/persona.ts
+++ b/lib/persona.ts
@@ -1,0 +1,27 @@
+import * as v from "valibot";
+
+export const UserPersonaSchema = v.object({
+  knownDomains: v.fallback(v.array(v.string()), []),
+  unknownDomains: v.fallback(v.array(v.string()), []),
+  feedbackHistory: v.fallback(
+    v.array(
+      v.object({
+        inference: v.fallback(v.string(), ""),
+        timestamp: v.fallback(v.number(), 0),
+      }),
+    ),
+    [],
+  ),
+});
+
+export type UserPersona = v.InferOutput<typeof UserPersonaSchema>;
+
+export const defaultPersona: UserPersona = {
+  knownDomains: [],
+  unknownDomains: [],
+  feedbackHistory: [],
+};
+
+export function parsePersona(value: unknown): UserPersona {
+  return v.parse(UserPersonaSchema, value ?? {});
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@prisma/client": "^7.5.0",
     "next": "16.2.1",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "valibot": "^1.3.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      valibot:
+        specifier: ^1.3.1
+        version: 1.3.1(typescript@5.9.3)
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.8
@@ -2996,6 +2999,14 @@ packages:
 
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  valibot@1.3.1:
+    resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -6238,6 +6249,10 @@ snapshots:
       punycode: 2.3.1
 
   valibot@1.2.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
+  valibot@1.3.1(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 


### PR DESCRIPTION
- app/[sessionId]/page.tsx: SSE購読・意訳表示・フィードバックボタン付き聴講者ビュー
- app/api/personalize/route.ts: userPersonaに基づくGemini意訳エンドポイント
- app/api/feedback/route.ts: わかりにくいフィードバックの推論・ペルソナ更新エンドポイント