### PR TITLE
polishTranscript関数のインポート元を修正し、校正システムプロンプトを追加

### DIFF
--- a/app/api/polish/route.ts
+++ b/app/api/polish/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { polishTranscript } from "@/lib/gemini";
+import { polishTranscript } from "@/lib/simplify";
 
 const MAX_TEXT_LENGTH = 5000;
 

--- a/lib/simplify.ts
+++ b/lib/simplify.ts
@@ -14,6 +14,32 @@ export type SimplifiedResult = {
 const SYSTEM_PROMPT = `専門用語・難しい言葉を小学生でもわかる言葉に言い換えてください。元の文章の意味・ニュアンスを変えないこと。専門用語と平易化した説明のペアも抽出してください。以下のJSON形式のみで返してください（マークダウン・前置きテキスト不要）:
 {"simplified": "平易化された文章", "terms": [{"word": "専門用語", "explanation": "平易化された説明"}]}`;
 
+const POLISH_SYSTEM_PROMPT = `あなたは音声認識テキストの校正アシスタントです。誤認識や言い淀み、繰り返しを修正し、自然で読みやすい文章に整えてください。内容は変えずに表現だけ改善し、修正後のテキストのみを返してください。`;
+
+export async function polishTranscript(rawText: string): Promise<string> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error("ANTHROPIC_API_KEY is not set");
+  }
+
+  const client = new Anthropic({ apiKey });
+
+  const message = await client.messages.create({
+    model: "claude-sonnet-4-20250514",
+    max_tokens: 2048,
+    system: POLISH_SYSTEM_PROMPT,
+    messages: [{ role: "user", content: rawText }],
+  });
+
+  const content = message.content[0];
+  if (content.type !== "text") {
+    throw new Error("Unexpected response type from Claude");
+  }
+
+  const result = content.text.trim();
+  return result !== "" ? result : rawText;
+}
+
 export async function simplify(text: string): Promise<SimplifiedResult> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {


### PR DESCRIPTION
## ✨ テキスト整形ロジックの刷新（Claude対応）

本PRでは、テキスト整形（polishing）処理を新しい実装に置き換え、それに伴いAPIルートのリファクタリングを行いました。

主な変更点は以下の通りです。

---

## 🧠 変更内容

### 🔧 APIルートのリファクタリング

* `app/api/polish/route.ts` におけるインポートを変更

  * `lib/gemini.ts` → `lib/simplify.ts`
* 新たに実装した `polishTranscript` を利用するように変更し、API全体で新しい整形ロジックを使用するよう統一

---

### ✨ テキスト整形処理の実装

* `lib/simplify.ts` に `polishTranscript` 関数を追加
* AnthropicのClaudeモデルを使用し、文字起こしテキストの以下を改善:

  * 可読性の向上
  * 文法や表現の自然さの修正
* 自然で正確な文章補正を行うための専用システムプロンプトを設計

---

## 📝 補足

* 従来のGeminiベース実装からの置き換えとなり、整形品質の向上を狙っています
* 他のテキスト処理ロジック（simplify機能）との統一も意識した構成になっています

---

Closes #<issue-number-if-any>
