### PR TITLE
ページレイアウトを更新し、フォントとスタイルを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/app/api/sessions/[id]/stream/route.test.ts
+++ b/app/api/sessions/[id]/stream/route.test.ts
@@ -66,7 +66,8 @@ describe("GET /api/sessions/[id]/stream", () => {
     const res = await GET(req, params);
     controller.abort();
 
-    const reader = res.body?.getReader();
+    // biome-ignore lint/style/noNonNullAssertion: res.body is always present in this test
+    const reader = res.body!.getReader();
     const { value } = await reader.read();
     const text = new TextDecoder().decode(value);
 

--- a/app/api/sessions/[id]/stream/route.test.ts
+++ b/app/api/sessions/[id]/stream/route.test.ts
@@ -66,7 +66,7 @@ describe("GET /api/sessions/[id]/stream", () => {
     const res = await GET(req, params);
     controller.abort();
 
-    const reader = res.body!.getReader();
+    const reader = res.body?.getReader();
     const { value } = await reader.read();
     const text = new TextDecoder().decode(value);
 

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { randomUUID } from "node:crypto";
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
+    <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`} suppressHydrationWarning>
       <body className="min-h-full flex flex-col">{children}</body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      suppressHydrationWarning
+    >
       <body className="min-h-full flex flex-col">{children}</body>
     </html>
   );

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,27 +1,29 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import Home from "./page";
 
-vi.mock("next/image", () => ({
-  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
-    // eslint-disable-next-line @next/next/no-img-element
-    return <img alt="" {...props} />;
-  },
+vi.mock("next/font/google", () => ({
+  Syne: () => ({ className: "syne" }),
+  Kosugi_Maru: () => ({ className: "kosugi" }),
+  Unbounded: () => ({ className: "unbounded" }),
 }));
 
+import Home from "./page";
+
 describe("Home", () => {
-  it("renders the heading", () => {
+  it("fumumu. ロゴが表示される", () => {
     render(<Home />);
-    expect(screen.getByText("To get started, edit the page.tsx file.")).toBeInTheDocument();
+    const logos = screen.getAllByText(/fumumu/);
+    expect(logos.length).toBeGreaterThan(0);
   });
 
-  it("renders the deploy link", () => {
+  it("始めるボタンが表示される", () => {
     render(<Home />);
-    expect(screen.getByText("Deploy Now")).toBeInTheDocument();
+    const buttons = screen.getAllByText(/始める/);
+    expect(buttons.length).toBeGreaterThan(0);
   });
 
-  it("renders the documentation link", () => {
+  it("キャッチコピーが表示される", () => {
     render(<Home />);
-    expect(screen.getByText("Documentation")).toBeInTheDocument();
+    expect(screen.getByText(/専門用語を、その場で、あなたの言葉に。/)).toBeInTheDocument();
   });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,52 +1,325 @@
-import Image from "next/image";
+import { Syne, Zen_Kaku_Gothic_New } from "next/font/google";
+
+const syne = Syne({ subsets: ["latin"], weight: ["400", "700", "800"] });
+const zen = Zen_Kaku_Gothic_New({ subsets: ["latin"], weight: ["300", "400"] });
 
 export default function Home() {
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image className="dark:invert" src="/next.svg" alt="Next.js logo" width={100} height={20} priority />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
+    <>
+      <style>{`
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { background: #fff; color: #1a1a1a; }
+
+        .btn-orange {
+          background: #ff6b35;
+          color: #fff;
+          border: none;
+          border-radius: 50px;
+          padding: 12px 28px;
+          font-size: 15px;
+          cursor: pointer;
+          transition: all 0.2s;
+          text-decoration: none;
+          display: inline-block;
+        }
+        .btn-orange:hover { background: #e85a24; }
+
+        .nav-btn {
+          background: #ff6b35;
+          color: #fff;
+          border: none;
+          border-radius: 50px;
+          padding: 10px 22px;
+          font-size: 14px;
+          cursor: pointer;
+          transition: all 0.2s;
+          text-decoration: none;
+        }
+        .nav-btn:hover { background: #e85a24; }
+
+        .role-card-speaker {
+          background: #ff6b35;
+          color: #fff;
+          border-radius: 20px;
+          padding: 48px 40px;
+          flex: 1;
+          transition: transform 0.2s;
+        }
+        .role-card-speaker:hover { transform: translateY(-4px); }
+
+        .role-card-listener {
+          background: #1a1a1a;
+          color: #fff;
+          border-radius: 20px;
+          padding: 48px 40px;
+          flex: 1;
+          transition: transform 0.2s;
+        }
+        .role-card-listener:hover { transform: translateY(-4px); }
+
+        .how-card {
+          border-radius: 16px;
+          padding: 36px 28px;
+          flex: 1;
+          min-width: 0;
+        }
+
+        @media (max-width: 768px) {
+          .concept-grid { grid-template-columns: 1fr !important; }
+          .how-grid { flex-direction: column !important; }
+          .role-grid { flex-direction: column !important; }
+          .hero-title { font-size: 56px !important; }
+          .logo-text { font-size: 28px !important; }
+        }
+      `}</style>
+
+      {/* Navbar */}
+      <nav
+        style={{
+          position: "sticky",
+          top: 0,
+          zIndex: 100,
+          background: "#fff",
+          borderBottom: "1px solid #f0ede8",
+          padding: "0 40px",
+          height: 64,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <span className={`logo-text ${syne.className}`} style={{ fontSize: 22, fontWeight: 800 }}>
+          fumumu<span style={{ color: "#ff6b35" }}>.</span>
+        </span>
+        <a href="/speaker" className={`nav-btn ${syne.className}`}>
+          始める
+        </a>
+      </nav>
+
+      {/* Hero */}
+      <section style={{ padding: "80px 40px 100px", maxWidth: 1200, margin: "0 auto" }}>
+        <div style={{ maxWidth: 640 }}>
+          <div>
+            <h1
+              className={`hero-title ${syne.className}`}
+              style={{ fontSize: 72, fontWeight: 800, lineHeight: 1.05, marginBottom: 24 }}
             >
-              Templates
-            </a>{" "}
-            or the{" "}
+              fumumu<span style={{ color: "#ff6b35" }}>.</span>
+            </h1>
+
+            <p className={zen.className} style={{ fontSize: 18, lineHeight: 1.9, color: "#aaa", marginBottom: 40 }}>
+              ふむむ、わかった。
+              <br />
+              専門用語を、その場で、
+              <br />
+              あなたの言葉に。
+            </p>
+
+            <a href="/speaker" className={`btn-orange ${syne.className}`}>
+              始める →
+            </a>
+          </div>
+
+        </div>
+      </section>
+
+      {/* Concept */}
+      <section style={{ background: "#fafaf8", padding: "100px 40px" }}>
+        <div
+          className="concept-grid"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 80,
+            maxWidth: 1200,
+            margin: "0 auto",
+            alignItems: "center",
+          }}
+        >
+          <div>
+            <h2 className={syne.className} style={{ fontSize: 48, fontWeight: 800, lineHeight: 1.2 }}>
+              「ふむむ」から
+              <br />
+              <span style={{ color: "#ff6b35" }}>「わかった！」</span>へ。
+            </h2>
+          </div>
+          <div>
+            <p className={zen.className} style={{ fontSize: 16, lineHeight: 2, color: "#aaa" }}>
+              学会・勉強会・社内発表。
+              <br />
+              専門知識の差が、理解の壁になる。
+              <br />
+              <br />
+              fumumu は発表をリアルタイムで文字起こしし、
+              <br />
+              聴講者ひとりひとりの知識レベルに合わせて
+              <br />
+              自動的に言い換えて届けます。
+              <br />
+              <br />
+              発表者はいつもどおり話すだけ。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* How it works */}
+      <section style={{ background: "#1a1a1a", padding: "100px 40px" }}>
+        <div style={{ maxWidth: 1200, margin: "0 auto" }}>
+          <div className="how-grid" style={{ display: "flex", gap: 20 }}>
+            {/* Card 1 */}
+            <div className="how-card" style={{ background: "#ff6b35" }}>
+              <svg
+                width="80"
+                height="80"
+                viewBox="0 0 80 80"
+                fill="none"
+                aria-hidden="true"
+                style={{ marginBottom: 24 }}
+              >
+                <rect x="18" y="10" width="44" height="60" rx="8" fill="rgba(0,0,0,0.15)" />
+                <rect x="22" y="16" width="36" height="36" rx="4" fill="#fff" fillOpacity="0.9" />
+                {/* QR pattern */}
+                <rect x="26" y="20" width="6" height="6" rx="1" fill="#ff6b35" />
+                <rect x="34" y="20" width="6" height="6" rx="1" fill="#ff6b35" />
+                <rect x="42" y="20" width="6" height="6" rx="1" fill="#ff6b35" />
+                <rect x="26" y="28" width="6" height="6" rx="1" fill="#ff6b35" />
+                <rect x="42" y="28" width="6" height="6" rx="1" fill="#ff6b35" />
+                <rect x="26" y="36" width="6" height="6" rx="1" fill="#ff6b35" />
+                <rect x="34" y="28" width="6" height="6" rx="1" fill="#ff6b35" />
+                <rect x="34" y="36" width="14" height="6" rx="1" fill="#ff6b35" />
+                {/* List items */}
+                <rect x="24" y="58" width="32" height="4" rx="2" fill="rgba(0,0,0,0.2)" />
+                <rect x="24" y="65" width="22" height="4" rx="2" fill="rgba(0,0,0,0.15)" />
+              </svg>
+              <h3 className={syne.className} style={{ fontSize: 22, fontWeight: 800, color: "#fff", marginBottom: 12 }}>QRを生成</h3>
+              <p className={zen.className} style={{ fontSize: 14, color: "rgba(255,255,255,0.8)", lineHeight: 1.8 }}>
+                発表者がセッションを作成。QRコードを投影するだけで準備完了。
+              </p>
+            </div>
+
+            {/* Card 2 */}
+            <div className="how-card" style={{ background: "#fff" }}>
+              <svg
+                width="80"
+                height="80"
+                viewBox="0 0 80 80"
+                fill="none"
+                aria-hidden="true"
+                style={{ marginBottom: 24 }}
+              >
+                <rect x="18" y="10" width="44" height="60" rx="8" fill="#f0ede8" />
+                <rect x="22" y="16" width="36" height="36" rx="4" fill="#fff" stroke="#e0ddd8" strokeWidth="1" />
+                {/* QR pattern small */}
+                <rect x="27" y="21" width="5" height="5" rx="1" fill="#1a1a1a" />
+                <rect x="34" y="21" width="5" height="5" rx="1" fill="#1a1a1a" />
+                <rect x="41" y="21" width="5" height="5" rx="1" fill="#1a1a1a" />
+                <rect x="27" y="28" width="5" height="5" rx="1" fill="#1a1a1a" />
+                <rect x="34" y="28" width="5" height="5" rx="1" fill="#1a1a1a" />
+                <rect x="41" y="28" width="5" height="5" rx="1" fill="#1a1a1a" />
+                <rect x="27" y="35" width="19" height="5" rx="1" fill="#1a1a1a" />
+                {/* Scan line */}
+                <line x1="22" y1="34" x2="58" y2="34" stroke="#ff6b35" strokeWidth="2" strokeDasharray="4 2">
+                  <animate attributeName="y1" values="16;52;16" dur="2s" repeatCount="indefinite" />
+                  <animate attributeName="y2" values="16;52;16" dur="2s" repeatCount="indefinite" />
+                </line>
+                <rect x="24" y="58" width="32" height="4" rx="2" fill="#e0ddd8" />
+                <rect x="24" y="65" width="22" height="4" rx="2" fill="#eeecea" />
+              </svg>
+              <h3 className={syne.className} style={{ fontSize: 22, fontWeight: 800, color: "#1a1a1a", marginBottom: 12 }}>QRを読む</h3>
+              <p className={zen.className} style={{ fontSize: 14, color: "#888", lineHeight: 1.8 }}>
+                聴講者はスマホでQRをスキャン。アプリ不要、ブラウザで即アクセス。
+              </p>
+            </div>
+
+            {/* Card 3 */}
+            <div className="how-card" style={{ background: "#fff3ee" }}>
+              <svg
+                width="80"
+                height="80"
+                viewBox="0 0 80 80"
+                fill="none"
+                aria-hidden="true"
+                style={{ marginBottom: 24 }}
+              >
+                {/* Original bubble */}
+                <rect x="8" y="12" width="36" height="24" rx="8" fill="#e0ddd8" />
+                <rect x="12" y="18" width="28" height="5" rx="2.5" fill="#bbb" />
+                <rect x="12" y="26" width="20" height="4" rx="2" fill="#ccc" />
+                <polygon points="16,36 24,36 20,42" fill="#e0ddd8" />
+                {/* Arrow */}
+                <circle cx="40" cy="50" r="10" fill="#ff6b35" />
+                <path
+                  d="M35 50 L43 50 M40 45 L45 50 L40 55"
+                  stroke="#fff"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                {/* Simplified bubble */}
+                <rect x="38" y="28" width="36" height="28" rx="8" fill="#fff0eb" stroke="#ffd4c2" strokeWidth="1.5" />
+                <rect x="43" y="34" width="26" height="5" rx="2.5" fill="#ffb39a" />
+                <rect x="43" y="42" width="20" height="4" rx="2" fill="#ffd4c2" />
+                <rect x="43" y="50" width="16" height="4" rx="2" fill="#ffd4c2" />
+                <polygon points="46,56 54,56 50,62" fill="#fff0eb" />
+              </svg>
+              <h3 className={syne.className} style={{ fontSize: 22, fontWeight: 800, color: "#1a1a1a", marginBottom: 12 }}>わかる言葉で届く</h3>
+              <p className={zen.className} style={{ fontSize: 14, color: "#888", lineHeight: 1.8 }}>
+                AIが専門用語を自動で言い換え。理解度に合わせてリアルタイムに翻訳。
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Role selection */}
+      <section style={{ background: "#fff", padding: "100px 40px" }}>
+        <div style={{ maxWidth: 900, margin: "0 auto" }}>
+          <div className="role-grid" style={{ display: "flex", gap: 20, marginBottom: 48 }}>
+            <div className={`role-card-speaker ${syne.className}`}>
+              <h3 style={{ fontSize: 32, fontWeight: 800, marginBottom: 16 }}>発表する</h3>
+              <p className={zen.className} style={{ fontSize: 14, color: "rgba(255,255,255,0.8)", lineHeight: 1.8 }}>
+                セッションを作成してQRコードを投影。
+                <br />
+                あとはいつもどおり話すだけ。
+              </p>
+            </div>
+
+            <div className={`role-card-listener ${syne.className}`}>
+              <h3 style={{ fontSize: 32, fontWeight: 800, marginBottom: 16 }}>参加する</h3>
+              <p className={zen.className} style={{ fontSize: 14, color: "rgba(255,255,255,0.5)", lineHeight: 1.8 }}>
+                QRをスキャンするだけ。
+                <br />
+                あなたのペルソナに合わせた言葉で届く。
+              </p>
+            </div>
+          </div>
+          <div style={{ textAlign: "center" }}>
             <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
+              href="/speaker"
+              className={`btn-orange ${syne.className}`}
+              style={{ fontSize: 16, padding: "14px 36px" }}
             >
-              Learning
-            </a>{" "}
-            center.
-          </p>
+              始める →
+            </a>
+          </div>
         </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image className="dark:invert" src="/vercel.svg" alt="Vercel logomark" width={16} height={16} />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
-    </div>
+      </section>
+
+      {/* Footer */}
+      <footer
+        style={{
+          background: "#111",
+          padding: "32px 40px",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <span className={syne.className} style={{ fontSize: 18, fontWeight: 800, color: "rgba(255,255,255,0.3)" }}>
+          fumumu<span style={{ color: "rgba(255,107,53,0.5)" }}>.</span>
+        </span>
+      </footer>
+    </>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import { Syne, Kosugi_Maru, Unbounded } from "next/font/google";
+import { Kosugi_Maru, Syne, Unbounded } from "next/font/google";
 
 const syne = Syne({ subsets: ["latin"], weight: ["400", "700", "800"] });
 const zen = Kosugi_Maru({ subsets: ["latin"], weight: ["400"] });
@@ -120,7 +120,9 @@ export default function Home() {
             <p className={zen.className} style={{ fontSize: 16, color: "rgba(255,255,255,0.65)", lineHeight: 1.8 }}>
               ふむむ、わかった。専門用語を、その場で、あなたの言葉に。
             </p>
-            <a href="/speaker" className={`btn-orange ${syne.className}`} style={{ flexShrink: 0 }}>始める →</a>
+            <a href="/speaker" className={`btn-orange ${syne.className}`} style={{ flexShrink: 0 }}>
+              始める →
+            </a>
           </div>
         </div>
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,8 @@
-import { Syne, Zen_Kaku_Gothic_New } from "next/font/google";
+import { Syne, Kosugi_Maru, Unbounded } from "next/font/google";
 
 const syne = Syne({ subsets: ["latin"], weight: ["400", "700", "800"] });
-const zen = Zen_Kaku_Gothic_New({ subsets: ["latin"], weight: ["300", "400"] });
+const zen = Kosugi_Maru({ subsets: ["latin"], weight: ["400"] });
+const unbounded = Unbounded({ subsets: ["latin"], weight: ["700"] });
 
 export default function Home() {
   return (
@@ -88,7 +89,7 @@ export default function Home() {
           justifyContent: "space-between",
         }}
       >
-        <span className={`logo-text ${syne.className}`} style={{ fontSize: 22, fontWeight: 800 }}>
+        <span className={`logo-text ${unbounded.className}`} style={{ fontSize: 18, fontWeight: 700 }}>
           fumumu<span style={{ color: "#ff6b35" }}>.</span>
         </span>
         <a href="/speaker" className={`nav-btn ${syne.className}`}>
@@ -97,29 +98,30 @@ export default function Home() {
       </nav>
 
       {/* Hero */}
-      <section style={{ padding: "80px 40px 100px", maxWidth: 1200, margin: "0 auto" }}>
-        <div style={{ maxWidth: 640 }}>
-          <div>
-            <h1
-              className={`hero-title ${syne.className}`}
-              style={{ fontSize: 72, fontWeight: 800, lineHeight: 1.05, marginBottom: 24 }}
-            >
-              fumumu<span style={{ color: "#ff6b35" }}>.</span>
-            </h1>
+      <section style={{ background: "#1a1a1a", padding: "80px 40px 72px", overflow: "hidden" }}>
+        <div style={{ maxWidth: 1200, margin: "0 auto" }}>
+          {/* giant title */}
+          <h1
+            className={unbounded.className}
+            style={{
+              fontSize: "clamp(72px, 14vw, 200px)",
+              fontWeight: 700,
+              lineHeight: 0.9,
+              color: "#fff",
+              letterSpacing: "-0.02em",
+              margin: "0 -4px 40px",
+            }}
+          >
+            fumumu<span style={{ color: "#ff6b35" }}>.</span>
+          </h1>
 
-            <p className={zen.className} style={{ fontSize: 18, lineHeight: 1.9, color: "#aaa", marginBottom: 40 }}>
-              ふむむ、わかった。
-              <br />
-              専門用語を、その場で、
-              <br />
-              あなたの言葉に。
+          {/* tagline + button */}
+          <div style={{ display: "flex", alignItems: "center", gap: 40, flexWrap: "wrap" }}>
+            <p className={zen.className} style={{ fontSize: 16, color: "rgba(255,255,255,0.65)", lineHeight: 1.8 }}>
+              ふむむ、わかった。専門用語を、その場で、あなたの言葉に。
             </p>
-
-            <a href="/speaker" className={`btn-orange ${syne.className}`}>
-              始める →
-            </a>
+            <a href="/speaker" className={`btn-orange ${syne.className}`} style={{ flexShrink: 0 }}>始める →</a>
           </div>
-
         </div>
       </section>
 
@@ -144,7 +146,7 @@ export default function Home() {
             </h2>
           </div>
           <div>
-            <p className={zen.className} style={{ fontSize: 16, lineHeight: 2, color: "#aaa" }}>
+            <p className={zen.className} style={{ fontSize: 16, lineHeight: 2, color: "#666" }}>
               学会・勉強会・社内発表。
               <br />
               専門知識の差が、理解の壁になる。
@@ -192,7 +194,7 @@ export default function Home() {
                 <rect x="24" y="58" width="32" height="4" rx="2" fill="rgba(0,0,0,0.2)" />
                 <rect x="24" y="65" width="22" height="4" rx="2" fill="rgba(0,0,0,0.15)" />
               </svg>
-              <h3 className={syne.className} style={{ fontSize: 22, fontWeight: 800, color: "#fff", marginBottom: 12 }}>QRを生成</h3>
+              <h3 style={{ fontSize: 22, fontWeight: 800, color: "#fff", marginBottom: 12 }}>QRを生成</h3>
               <p className={zen.className} style={{ fontSize: 14, color: "rgba(255,255,255,0.8)", lineHeight: 1.8 }}>
                 発表者がセッションを作成。QRコードを投影するだけで準備完了。
               </p>
@@ -226,8 +228,8 @@ export default function Home() {
                 <rect x="24" y="58" width="32" height="4" rx="2" fill="#e0ddd8" />
                 <rect x="24" y="65" width="22" height="4" rx="2" fill="#eeecea" />
               </svg>
-              <h3 className={syne.className} style={{ fontSize: 22, fontWeight: 800, color: "#1a1a1a", marginBottom: 12 }}>QRを読む</h3>
-              <p className={zen.className} style={{ fontSize: 14, color: "#888", lineHeight: 1.8 }}>
+              <h3 style={{ fontSize: 22, fontWeight: 800, color: "#1a1a1a", marginBottom: 12 }}>QRを読む</h3>
+              <p className={zen.className} style={{ fontSize: 14, color: "#555", lineHeight: 1.8 }}>
                 聴講者はスマホでQRをスキャン。アプリ不要、ブラウザで即アクセス。
               </p>
             </div>
@@ -263,8 +265,8 @@ export default function Home() {
                 <rect x="43" y="50" width="16" height="4" rx="2" fill="#ffd4c2" />
                 <polygon points="46,56 54,56 50,62" fill="#fff0eb" />
               </svg>
-              <h3 className={syne.className} style={{ fontSize: 22, fontWeight: 800, color: "#1a1a1a", marginBottom: 12 }}>わかる言葉で届く</h3>
-              <p className={zen.className} style={{ fontSize: 14, color: "#888", lineHeight: 1.8 }}>
+              <h3 style={{ fontSize: 22, fontWeight: 800, color: "#1a1a1a", marginBottom: 12 }}>わかる言葉で届く</h3>
+              <p className={zen.className} style={{ fontSize: 14, color: "#555", lineHeight: 1.8 }}>
                 AIが専門用語を自動で言い換え。理解度に合わせてリアルタイムに翻訳。
               </p>
             </div>
@@ -287,7 +289,7 @@ export default function Home() {
 
             <div className={`role-card-listener ${syne.className}`}>
               <h3 style={{ fontSize: 32, fontWeight: 800, marginBottom: 16 }}>参加する</h3>
-              <p className={zen.className} style={{ fontSize: 14, color: "rgba(255,255,255,0.5)", lineHeight: 1.8 }}>
+              <p className={zen.className} style={{ fontSize: 14, color: "rgba(255,255,255,0.85)", lineHeight: 1.8 }}>
                 QRをスキャンするだけ。
                 <br />
                 あなたのペルソナに合わせた言葉で届く。
@@ -316,7 +318,7 @@ export default function Home() {
           alignItems: "center",
         }}
       >
-        <span className={syne.className} style={{ fontSize: 18, fontWeight: 800, color: "rgba(255,255,255,0.3)" }}>
+        <span className={unbounded.className} style={{ fontSize: 14, fontWeight: 700, color: "rgba(255,255,255,0.3)" }}>
           fumumu<span style={{ color: "rgba(255,107,53,0.5)" }}>.</span>
         </span>
       </footer>

--- a/lib/llm.test.ts
+++ b/lib/llm.test.ts
@@ -118,7 +118,7 @@ describe("translate ステップ", () => {
 describe("simplify ステップ — JSON パース", () => {
   it("マークダウンコードブロックで囲まれた JSON も正しくパースする", async () => {
     const json = JSON.stringify({ text: "平易な文", terms: [] });
-    createMock.mockResolvedValue(textResponse("```json\n" + json + "\n```"));
+    createMock.mockResolvedValue(textResponse(`\`\`\`json\n${json}\n\`\`\``));
 
     const step = defaultPipeline.find((s) => s.name === "simplify")!;
     const result = await runPipeline("テスト", [step]);

--- a/lib/simplify.test.ts
+++ b/lib/simplify.test.ts
@@ -36,7 +36,7 @@ describe("simplify", () => {
 
   it("マークダウンコードブロックで囲まれたJSONも正しくパースする", async () => {
     createMock.mockResolvedValue({
-      content: [{ type: "text", text: "```json\n" + VALID_JSON + "\n```" }],
+      content: [{ type: "text", text: `\`\`\`json\n${VALID_JSON}\n\`\`\`` }],
     });
 
     const result = await simplify("難しいテキスト");


### PR DESCRIPTION
## 🎨 ランディングページの全面刷新とブランドデザインの導入

本PRでは、従来のNext.jsのスターターページを廃止し、「fumumu」専用のマーケティング用ランディングページへ全面的にリニューアルしました。
あわせて、ルートレイアウトに軽微な技術的改善を加えています。

---

## 🧠 変更内容

### ✨ ホームページの刷新とブランディング

* `app/page.tsx` を完全に再設計し、「fumumu」専用のトップページを実装
* 以下のセクションを新規追加:

  * ヒーローセクション
  * コンセプト説明
  * 使い方（How it works）
  * ロール選択UI
  * フッター
* 日本語コピーとビジュアルを統一し、サービスの世界観を明確化
* Google Fonts（Syne / Zen Kaku Gothic New）を使用し、独自のトーンを演出

---

### 🎨 スタイリングとレイアウト改善

* ホームページにおけるスタイルをインラインCSSで実装

  * レイアウト、レスポンシブ対応、コンポーネントデザイン（ボタン・カード・グリッドなど）
* Tailwind依存を排除し、デザインの自由度を向上
* 未使用のimport（例: Next.jsの `Image`）や既存のプレースホルダーを削除

---

### ⚙️ 技術的改善

* `app/layout.tsx` を更新

  * `<html>` に `suppressHydrationWarning` を追加
  * 動的スタイルやインラインCSSによるHydration mismatchを防止

---

## 📝 補足

* テンプレートベースのUIから脱却し、プロダクトの価値を伝えるための構成へ変更
* デザインとコピーの一貫性を重視した設計

---

## 🔮 今後の展望

* アニメーションやインタラクションの追加
* コンポーネント分割による再利用性の向上
* A/Bテストによるコンバージョン改善

---

Closes #<issue-number-if-any>
