### PR TITLE
Fix three bugs: wrong model ID, missing error handling, and resource leak

### DIFF
--- a/app/speaker/page.tsx
+++ b/app/speaker/page.tsx
@@ -246,6 +246,13 @@ export default function SpeakerPage() {
       });
 
       socket.on("close", () => {
+        processorRef.current?.disconnect();
+        processorRef.current = null;
+        void audioCtxRef.current?.close();
+        audioCtxRef.current = null;
+        for (const t of streamRef.current?.getTracks() ?? []) t.stop();
+        streamRef.current = null;
+        socketRef.current = null;
         setStatus("idle");
       });
 

--- a/lib/llm.test.ts
+++ b/lib/llm.test.ts
@@ -135,10 +135,13 @@ describe("simplify ステップ — JSON パース", () => {
     expect(result.terms).toEqual([]);
   });
 
-  it("不正な JSON の場合エラーをthrowする", async () => {
+  it("不正な JSON の場合は元テキストにフォールバックする", async () => {
     createMock.mockResolvedValue(textResponse("not json"));
 
     const step = getPipelineStep("simplify");
-    await expect(runPipeline("テスト", [step])).rejects.toThrow(SyntaxError);
+    const result = await runPipeline("テスト", [step]);
+
+    expect(result.output).toBe("テスト");
+    expect(result.terms).toEqual([]);
   });
 });

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -1,7 +1,7 @@
 import * as v from "valibot";
 import { extractText, getClient, parseJsonResponse } from "@/lib/claude";
 
-const MODEL = "claude-haiku-4-5";
+const MODEL = "claude-haiku-4-5-20251001";
 
 export type PipelineStep = {
   name: string;
@@ -66,8 +66,12 @@ async function simplifyStep(text: string): Promise<{ output: string; terms: Term
   });
   const raw = extractText(response);
   if (!raw) return { output: text, terms: [] };
-  const parsed = parseJsonResponse(SimplifyResponseSchema, raw);
-  return { output: parsed.text, terms: parsed.terms };
+  try {
+    const parsed = parseJsonResponse(SimplifyResponseSchema, raw);
+    return { output: parsed.text, terms: parsed.terms };
+  } catch {
+    return { output: text, terms: [] };
+  }
 }
 
 async function translateStep(text: string): Promise<string> {


### PR DESCRIPTION
- lib/llm.ts: Fix model ID from "claude-haiku-4-5" to "claude-haiku-4-5-20251001"
  (the former does not exist; all API calls to the simplify pipeline would fail)
- lib/llm.ts: Add try/catch around parseJsonResponse in simplifyStep so that
  malformed LLM responses fall back to the original text instead of crashing
  the entire pipeline
- app/speaker/page.tsx: Fix socket close handler to properly clean up audio
  resources (ScriptProcessorNode, AudioContext, MediaStream tracks) on unexpected
  WebSocket disconnection; previously only setStatus("idle") was called, leaving
  the microphone open

https://claude.ai/code/session_01TRPawt7hDUfnDNckyzXyAf